### PR TITLE
Update plugin to support Minecraft 1.13+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <groupId>me.kernelfreeze</groupId>
     <artifactId>minerstorch</artifactId>
     <version>1.0</version>
+
     <build>
         <plugins>
             <plugin>
@@ -14,38 +15,26 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
     <repositories>
         <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
+
     <dependencies>
-        <!--Spigot API-->
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
         <!--Bukkit API-->
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <!--Bukkit API-->
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>craftbukkit</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.13.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/kernelfreeze/minerstorch/MinersTorch.java
+++ b/src/main/java/me/kernelfreeze/minerstorch/MinersTorch.java
@@ -1,14 +1,13 @@
 package me.kernelfreeze.minerstorch;
 
-import org.bukkit.Server;
-import org.bukkit.plugin.PluginManager;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public class MinersTorch
-  extends JavaPlugin
-{
-  public void onEnable()
-  {
-    getServer().getPluginManager().registerEvents(new TorchListener(this), this);
-  }
+public final class MinersTorch extends JavaPlugin {
+
+    @Override
+    public void onEnable() {
+        Bukkit.getPluginManager().registerEvents(new TorchListener(), this);
+    }
+
 }

--- a/src/main/java/me/kernelfreeze/minerstorch/TorchListener.java
+++ b/src/main/java/me/kernelfreeze/minerstorch/TorchListener.java
@@ -1,83 +1,58 @@
 package me.kernelfreeze.minerstorch;
 
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Directional;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.material.Torch;
 
-public class TorchListener
-  implements Listener
-{
-  private final MinersTorch plugin;
-  
-  public TorchListener(MinersTorch plugin)
-  {
-    this.plugin = plugin;
-  }
-  
-  @EventHandler
-  public void onPlayerInteract(PlayerInteractEvent event)
-  {
-    if (event.getAction() == Action.RIGHT_CLICK_BLOCK)
-    {
-      Player player = event.getPlayer();
-      switch (player.getItemInHand().getType())
-      {
-      case GOLD_PICKAXE: 
-      case IRON_PICKAXE: 
-      case STONE_PICKAXE: 
-      case WOOD_PICKAXE: 
-      case DIAMOND_PICKAXE: 
+public class TorchListener implements Listener {
+
+    // TODO: 1.16 - Support netherrite pickaxe
+    private static final Set<Material> PICKAXES = EnumSet.of(Material.WOODEN_PICKAXE, Material.STONE_PICKAXE, Material.GOLDEN_PICKAXE, Material.IRON_PICKAXE, Material.DIAMOND_PICKAXE);
+    private static final ItemStack TORCH = new ItemStack(Material.TORCH, 1); // Amount of 1 - for implementation
+
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        ItemStack item = event.getItem();
+        Block block = event.getClickedBlock();
+        BlockFace face = event.getBlockFace();
+        if (item == null || block == null || face == BlockFace.DOWN || event.getAction() != Action.RIGHT_CLICK_BLOCK || !PICKAXES.contains(item.getType())) {
+            return;
+        }
+
+        block = block.getRelative(face);
+        if (block.getType() != Material.AIR) {
+            return;
+        }
+
+        Player player = event.getPlayer();
         if (!player.hasPermission("minerstorch.place")) {
-          return;
-        }
-        if (player.hasPermission("minerstorch.unlimited"))
-        {
-          BlockFace face = event.getBlockFace();
-          Block block = event.getClickedBlock().getRelative(face);
-          if (block.getType() != Material.AIR) {
             return;
-          }
-          Torch torch = new Torch();
-          torch.setFacingDirection(face);
-          player.playSound(block.getLocation(), Sound.DIG_WOOD, 10.0F, 1.0F);
-          
-          block.setTypeIdAndData(torch.getItemTypeId(), torch.getData(), true);
         }
-        else if (player.getInventory().contains(Material.TORCH))
-        {
-          BlockFace face = event.getBlockFace();
-          Block block = event.getClickedBlock().getRelative(face);
-          if (block.getType() != Material.AIR) {
+
+        // If they have the permission, the torch removal will not be called. If they don't and the torch couldn't be removed, they had no torches
+        if (!player.hasPermission("minerstorch.unlimited") && !player.getInventory().removeItem(TORCH).isEmpty()) {
             return;
-          }
-          Torch torch = new Torch();
-          torch.setFacingDirection(face);
-          
-          PlayerInventory inventory = player.getInventory();
-          int slot = inventory.first(Material.TORCH);
-          ItemStack stack = inventory.getItem(slot);
-          if (stack.getAmount() < 1) {
-            return;
-          }
-          if (stack.getAmount() <= 1) {
-            inventory.remove(stack);
-          } else {
-            inventory.setItem(slot, new ItemStack(Material.TORCH, stack.getAmount() - 1));
-          }
-          player.playSound(block.getLocation(), Sound.DIG_WOOD, 10.0F, 1.0F);
-          block.setTypeIdAndData(torch.getItemTypeId(), torch.getData(), true);
         }
-        break;
-      }
+
+        if (face == BlockFace.UP) {
+            block.setType(Material.TORCH);
+        } else {
+            block.setBlockData(Bukkit.createBlockData(Material.WALL_TORCH, t -> ((Directional) t).setFacing(face)));
+        }
+
+        player.playSound(block.getLocation(), Sound.BLOCK_WOOD_PLACE, 1.0F, 1.0F);
     }
-  }
+
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,8 @@
-name: Miners torch
+name: Minerstorch
 description: You can place torches with your pickage
 main: me.kernelfreeze.minerstorch.MinersTorch
 version: 1.0
+api-version: 1.13
 permissions:
     minerstorch.*:
         description: Gives access to all Miners torch features


### PR DESCRIPTION
This PR is quick and simple to update the plugin to 1.13+ as per user request at the following forum thread:
https://www.spigotmc.org/threads/miners-torch-does-not-work-at-1-15-2-source.437245/

This PR also ensures future-proof design though will no longer support Minecraft 1.12 or below as it uses modern Material constants. This plugin will, however, also require an update post-1.16 to include the netherite pickaxes in the PICKAXES Set constant.